### PR TITLE
✨ Enable port forwarding for devcontainer-cli

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,13 +2,11 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/javascript-node
 {
 	"name": "Node.js",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 18, 16, 14.
-		// Append -bullseye or -buster to pin to an OS version.
-		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "16-bullseye" }
-	},
+	"dockerComposeFile": [
+		"./docker-compose.yml"
+	],
+	"service": "main",
+	"shutdownAction": "stopCompose",
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -23,11 +21,12 @@
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [8000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"workspaceFolder": "/workspaces/zenn-docs",
 	"remoteUser": "node"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  main:
+    container_name: vcs-zenn-docs
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VARIANT: "16-bullseye"
+    tty: true
+    volumes:
+      - type: bind
+        source: ..
+        target: /workspaces/zenn-docs
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    ports:
+      - "8000:8000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "textlint-rule-preset-ja-spacing": "^2.2.0",
         "textlint-rule-preset-ja-technical-writing": "^7.0.0",
         "textlint-rule-spellcheck-tech-word": "^5.0.0",
-        "zenn-cli": "^0.1.114"
+        "zenn-cli": "^0.1.122"
       }
     },
     "node_modules/@azu/format-text": {
@@ -3626,9 +3626,9 @@
       }
     },
     "node_modules/zenn-cli": {
-      "version": "0.1.114",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.114.tgz",
-      "integrity": "sha512-8dpBVfywzxyqPo8jAhRECYsb9IZHgF3KzVnj6rGdZPPPaa/GwQThvIf6FjyEnXQaU6JKq7jjnpi+aSYs1hXEYQ==",
+      "version": "0.1.122",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.122.tgz",
+      "integrity": "sha512-bJfaj9cbQV01jnFqn9wEYJgtPDJs2pibFN0SGOkICQ/ku03ScC4KDVq9/CYHb33s/hlgbcclhnqPyCpESdoCGw==",
       "bin": {
         "zenn": "dist/server/zenn.js"
       },
@@ -6498,9 +6498,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "zenn-cli": {
-      "version": "0.1.114",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.114.tgz",
-      "integrity": "sha512-8dpBVfywzxyqPo8jAhRECYsb9IZHgF3KzVnj6rGdZPPPaa/GwQThvIf6FjyEnXQaU6JKq7jjnpi+aSYs1hXEYQ=="
+      "version": "0.1.122",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.122.tgz",
+      "integrity": "sha512-bJfaj9cbQV01jnFqn9wEYJgtPDJs2pibFN0SGOkICQ/ku03ScC4KDVq9/CYHb33s/hlgbcclhnqPyCpESdoCGw=="
     },
     "zlibjs": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^7.0.0",
     "textlint-rule-spellcheck-tech-word": "^5.0.0",
-    "zenn-cli": "^0.1.114"
+    "zenn-cli": "^0.1.122"
   }
 }


### PR DESCRIPTION
## 概要

devcotnainer-cliで作成した場合にポートフォワーディングがされなかった。VSCodeからdevcontainerを起動する場合は、VSCodeがいい感じに設定していたため、気にする必要がなかったよう。

docker-composeでコンテナを起動する際にポートフォワーディングの設定を記述するようにして対応した。